### PR TITLE
fix: 修复 circle 屏多拼候选与拼音小字行显示

### DIFF
--- a/components/InputMethod/InputMethod.ux
+++ b/components/InputMethod/InputMethod.ux
@@ -5,8 +5,11 @@
          之后 keyboardCreated 保活、hide 切换只走内层 show 显隐，不重复重建。 -->
     <div if="{{!hide || keyboardCreated}}">
       <div show="{{!hide}}" style="background-color:black;flex-direction: column;" >
-      <!-- 拼音小字行：键盘框外上方单独一行，黑底覆盖，仅中/日模式且有 cval 时显示，只展示不可点 -->
-      <div class="cvalrow-wrap" show="{{(lang==='cn' || lang==='jp') && downFlag==='' && !numFlag && cval}}">
+      <!-- 拼音小字行：键盘框外上方单独一行，黑底覆盖，仅中/日模式且有 cval 时显示，只展示不可点。
+           circle 屏彻底不建此节点（键盘固定 480x321，外置 28px 行会挤压键盘且顶部多一条黑条），
+           circle 的拼音改在键盘内部绝对定位显示；if 而非 show：show 隐藏时节点仍在 VDOM，
+           circle 顶部会残留黑条 -->
+      <div if="{{screentype !== 'circle'}}" class="cvalrow-wrap" show="{{(lang==='cn' || lang==='jp') && downFlag==='' && !numFlag && cval}}">
         <text class="cvalrow">{{cvalDisplay}}</text>
       </div>
       <!-- 圆屏62 -->
@@ -24,11 +27,17 @@
           <!-- 带变量的相对路径在 aiot-tookit 2.0.4 中修复 -->
           <img src="./assets/full/{{lang}}.png" style="position: absolute;top:38px;left:7px;width:67px;height:52px;" @click="onBtnClick('lang')" if="{{downFlag==='' && !numFlag && lang!='jp'}}" />
           <img src="./assets/full/jp.png" style="position: absolute;top:38px;left:7px;width:67px;height:52px;" @click="onBtnClick('lang')" if="{{downFlag==='' && !numFlag && lang==='jp'}}" />
-          <!-- 候选行：整词在前、单字随后 -->
-          <div style="position: absolute;top:38px;left:80px;width:277px" show="{{(lang === 'cn' || lang === 'jp') && !numFlag}}">
-            <div class="item column center" for="{{resultRow0}}">
-              <input class="calbtn0" type="button" value="{{resultRow0[$idx]}}" @click="onRsSelect(resultRow0[$idx])" />
-            </div>
+          <!-- 拼音小字行：circle 屏在键盘内部绝对定位（对齐参考工程），浮于候选行上方，不占键盘高度 -->
+          <div style="position: absolute;top:-4px;left:78px;width:324px;" show="{{(lang==='cn' || lang==='jp') && downFlag==='' && !numFlag && cval}}">
+            <text class="caltext" style="width:296px;">{{cvalDisplay}}_</text>
+          </div>
+          <!-- 候选横滚行：整词在前、单字随后，宽度自适应防长词拥挤（对齐 rect/pill 屏方案），容器止于右侧 down 箭头前 -->
+          <div style="position: absolute;top:38px;left:78px;width:275px;height:52px;" show="{{(lang === 'cn' || lang === 'jp') && !numFlag}}">
+            <scroll scroll-x="{{true}}" style="position:absolute;left:0px;width:100%;height:42px;">
+              <div style="position: absolute;left: 0px;height: 42px;padding-left:20px;padding-right:20px">
+                <text for="{{resultRow0}}" show="{{resultRow0.length > $idx}}" class="calbtn02" style="padding-right:10px" @click="onRsSelect(resultRow0[$idx])">{{resultRow0[$idx]}}</text>
+              </div>
+            </scroll>
           </div>
           <div style="position: absolute;top:38px;left:80px;width:320px;height:52px;align-content: center;align-items: center;justify-content: center" show="{{downFlag==='' && !numFlag && lang==='en'}}" @click="onBtnClick('switchNum')" >
             <img src="./assets/full/123_boardless.png" />
@@ -94,11 +103,18 @@
           <div show="{{downFlag==='' && !numFlag}}" style="position: absolute;top:-4px;left:240px;width:145px;height:40px;justify-content:flex-end">
             <text for="{{waitingList}}" class="waiting-keys" style="color:{{$idx===waitingIndex ? 'rgb(13,132,255)' : 'white'}};" @click="onSelectWaiting($idx)">{{waitingList[$idx]}}</text>
           </div>
-          <!-- 候选行：整词在前、单字随后 -->
-          <div style="position: absolute;top:39px;left:105px;width:233px" show="{{lang === 'cn' && !numFlag}}">
-            <div class="item column center" for="{{resultRow0}}">
-              <input class="calbtn0" type="button" value="{{resultRow0[$idx]}}" @click="onRsSelect(resultRow0[$idx])" />
-            </div>
+          <!-- 拼音小字行：circle 屏在键盘内部绝对定位（对齐参考工程），浮于候选行上方，不占键盘高度；左止于 waiting 列表前 -->
+          <div style="position: absolute;top:-4px;left:95px;width:145px;height:40px;" show="{{(lang==='cn' || lang==='jp') && downFlag==='' && !numFlag && cval}}">
+            <text class="caltext" style="width:145px;">{{cvalDisplay}}_</text>
+          </div>
+          <!-- 候选横滚行：整词在前、单字随后，宽度自适应防长词拥挤（对齐 rect/pill 屏方案），容器止于右侧 down 箭头前。
+               注意：容器必须给 height（scroll 在无高度容器内不渲染内容，T9 候选曾因此空白） -->
+          <div style="position: absolute;top:39px;left:105px;width:233px;height:52px;" show="{{(lang === 'cn' || lang === 'jp') && !numFlag}}">
+            <scroll scroll-x="{{true}}" style="position:absolute;left:0px;width:100%;height:42px;">
+              <div style="position: absolute;left: 0px;height: 42px;padding-left:20px;padding-right:20px">
+                <text for="{{resultRow0}}" show="{{resultRow0.length > $idx}}" class="calbtn02" style="padding-right:10px" @click="onRsSelect(resultRow0[$idx])">{{resultRow0[$idx]}}</text>
+              </div>
+            </scroll>
           </div>
           <div style="position: absolute;top:35px;left:95px;width:290px;height:60px;align-content: center;align-items: center;justify-content: center" show="{{downFlag==='' && !numFlag && lang==='en'}}" @click="onBtnClick('switchNum')" >
             <img src="./assets/full/123_boardless.png" />


### PR DESCRIPTION
## 问题
circle（圆屏）键盘为固定 480x321 布局，多拼功能引入的候选行/拼音小字行存在显示问题：
- 外置拼音小字行会挤压键盘高度，顶部残留黑条
- 候选行使用固定宽度按钮，整词过长时拥挤/截断

## 修改
- 拼音小字行：circle 屏改为键盘内部绝对定位显示（对齐参考工程），不占键盘高度；外部小字行节点改用 if 不建树，避免残留黑条
- 候选行：改为可横滚、文字宽度自适应（对齐 rect/pill 屏方案），容器止于右侧下展箭头前
- 候选行容器补齐 height，保证 scroll 在无高度容器内正常渲染内容

## 涉及文件
- components/InputMethod/InputMethod.ux